### PR TITLE
Device ID in ODK Pulldata CSV

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -5,7 +5,7 @@ build:
     - java -version
     - gradle --version
     - gradle clean
-    - gradle test --info
+    - gradle test
 notify:
   email:
     from: $$FROM

--- a/src/main/java/com/onaio/steps/handler/strategies/survey/TakeSurveyForHouseholdStrategy.java
+++ b/src/main/java/com/onaio/steps/handler/strategies/survey/TakeSurveyForHouseholdStrategy.java
@@ -24,6 +24,7 @@ import com.onaio.steps.R;
 import com.onaio.steps.handler.strategies.survey.interfaces.ITakeSurveyStrategy;
 import com.onaio.steps.helper.Constants;
 import com.onaio.steps.helper.DatabaseHelper;
+import com.onaio.steps.helper.KeyValueStoreFactory;
 import com.onaio.steps.model.Household;
 import com.onaio.steps.model.InterviewStatus;
 import com.onaio.steps.model.ODKForm.ODKForm;
@@ -32,6 +33,8 @@ import com.onaio.steps.model.ODKForm.strategy.HouseholdMemberFormStrategy;
 import com.onaio.steps.model.RequestCode;
 
 import java.io.IOException;
+
+import static com.onaio.steps.helper.Constants.HH_PHONE_ID;
 
 public class TakeSurveyForHouseholdStrategy  implements ITakeSurveyStrategy {
     private Household household;
@@ -47,7 +50,8 @@ public class TakeSurveyForHouseholdStrategy  implements ITakeSurveyStrategy {
     public void open(String formId) throws IOException {
         String formName = String.format(formId + "-%s", household.getName());
         ODKForm requiredForm = ODKForm.create(activity, formId, formName);
-        requiredForm.open(new HouseholdMemberFormStrategy(household), activity, RequestCode.SURVEY.getCode());
+        String deviceId = getDeviceId();
+        requiredForm.open(new HouseholdMemberFormStrategy(household, deviceId), activity, RequestCode.SURVEY.getCode());
     }
 
     public boolean shouldInactivate(){
@@ -79,5 +83,9 @@ public class TakeSurveyForHouseholdStrategy  implements ITakeSurveyStrategy {
             button.setText(R.string.continue_interview);
         else
             button.setText(R.string.interview_now);
+    }
+
+    public String getDeviceId() {
+        return KeyValueStoreFactory.instance(activity).getString(HH_PHONE_ID);
     }
 }

--- a/src/main/java/com/onaio/steps/handler/strategies/survey/TakeSurveyForParticipantStrategy.java
+++ b/src/main/java/com/onaio/steps/handler/strategies/survey/TakeSurveyForParticipantStrategy.java
@@ -24,6 +24,7 @@ import com.onaio.steps.R;
 import com.onaio.steps.handler.strategies.survey.interfaces.ITakeSurveyStrategy;
 import com.onaio.steps.helper.Constants;
 import com.onaio.steps.helper.DatabaseHelper;
+import com.onaio.steps.helper.KeyValueStoreFactory;
 import com.onaio.steps.model.InterviewStatus;
 import com.onaio.steps.model.ODKForm.ODKForm;
 import com.onaio.steps.model.ODKForm.ODKSavedForm;
@@ -48,7 +49,8 @@ public class TakeSurveyForParticipantStrategy implements ITakeSurveyStrategy {
     public void open(String formId) throws IOException {
         String formName = String.format(formId + "-%s", participant.getParticipantID());
         ODKForm requiredForm = ODKForm.create(activity, formId, formName);
-        requiredForm.open(new ParticipantFormStrategy(participant), activity, RequestCode.SURVEY.getCode());
+        String deviceId = getDeviceId();
+        requiredForm.open(new ParticipantFormStrategy(participant, deviceId), activity, RequestCode.SURVEY.getCode());
     }
 
     @Override
@@ -83,4 +85,7 @@ public class TakeSurveyForParticipantStrategy implements ITakeSurveyStrategy {
             button.setText(R.string.enter_data_now);
     }
 
+    public String getDeviceId() {
+        return KeyValueStoreFactory.instance(activity).getString(Constants.PA_PHONE_ID);
+    }
 }

--- a/src/main/java/com/onaio/steps/helper/Constants.java
+++ b/src/main/java/com/onaio/steps/helper/Constants.java
@@ -50,8 +50,8 @@ public class Constants {
 
 
 //    public static final String ODK_FORM_ID = "steps_draft_testing";
-    public static final String ODK_FORM_FIELDS = "hhid_key,form_name,member_id,family_surname,first_name,gender,age,hh_size";
-    public static final String PARTICIPANT_ODK_FORM_FIELDS = "hhid_key,form_name,member_id,family_surname,first_name,gender,age,hh_size";
+    public static final String ODK_FORM_FIELDS = "hhid_key,form_name,member_id,family_surname,first_name,gender,age,hh_size,device_id";
+    public static final String PARTICIPANT_ODK_FORM_FIELDS = "hhid_key,form_name,member_id,family_surname,first_name,gender,age,hh_size,device_id";
     public static final String ODK_DATA_FILENAME = "STEPS.csv";
     public static final String ODK_HH_ID = "1";
 

--- a/src/main/java/com/onaio/steps/model/ODKForm/strategy/HouseholdMemberFormStrategy.java
+++ b/src/main/java/com/onaio/steps/model/ODKForm/strategy/HouseholdMemberFormStrategy.java
@@ -34,11 +34,13 @@ public class HouseholdMemberFormStrategy implements IFormStrategy{
 
     private Household household;
     private FileUtil fileUtil;
+    private String deviceId;
 
 
-    public HouseholdMemberFormStrategy(Household household){
+    public HouseholdMemberFormStrategy(Household household, String deviceId){
         this.household = household;
         fileUtil = new FileUtil();
+        this.deviceId = deviceId;
     }
 
     @Override
@@ -56,6 +58,7 @@ public class HouseholdMemberFormStrategy implements IFormStrategy{
         row.add(String.valueOf(selectedMember.getGender().getIntValue()));
         row.add(String.valueOf(selectedMember.getAge()));
         row.add(String.valueOf(household.numberOfNonDeletedMembers(databaseHelper)));
+        row.add(deviceId);
         fileUtil.withHeader(Constants.ODK_FORM_FIELDS.split(","))
                 .withData(row.toArray(new String[row.size()]))
                 .writeCSV(pathToSaveDataFile + "/" + Constants.ODK_DATA_FILENAME);

--- a/src/main/java/com/onaio/steps/model/ODKForm/strategy/ParticipantFormStrategy.java
+++ b/src/main/java/com/onaio/steps/model/ODKForm/strategy/ParticipantFormStrategy.java
@@ -32,12 +32,12 @@ public class ParticipantFormStrategy implements IFormStrategy{
     private Participant participant;
     private FileUtil fileUtil;
     private static final String HH_SIZE = "1";
+    private String deviceId;
 
-
-    public ParticipantFormStrategy(Participant participant){
+    public ParticipantFormStrategy(Participant participant, String deviceId){
         this.participant = participant;
         this.fileUtil = new FileUtil();
-
+        this.deviceId = deviceId;
     }
     @Override
     public void saveDataFile(Activity activity, String pathToSaveDataFile) throws IOException {
@@ -52,6 +52,7 @@ public class ParticipantFormStrategy implements IFormStrategy{
         row.add(String.valueOf(participant.getGender().getIntValue()));
         row.add(String.valueOf(participant.getAge()));
         row.add(HH_SIZE);
+        row.add(deviceId);
         fileUtil.withHeader(Constants.PARTICIPANT_ODK_FORM_FIELDS.split(","))
                 .withData(row.toArray(new String[row.size()]))
                 .writeCSV(pathToSaveDataFile + "/" + Constants.ODK_DATA_FILENAME);

--- a/src/test/java/com/onaio/steps/model/ODKForm/ODKFormTest.java
+++ b/src/test/java/com/onaio/steps/model/ODKForm/ODKFormTest.java
@@ -50,6 +50,8 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.onaio.steps.helper.Constants.HH_PHONE_ID;
+
 @RunWith(RobolectricTestRunner.class)
 @Config(emulateSdk = 16, manifest = "src/main/AndroidManifest.xml",shadows = {ShadowDatabaseHelper.class})
 public class ODKFormTest extends TestCase {
@@ -104,9 +106,9 @@ public class ODKFormTest extends TestCase {
         Mockito.stub(blankFormMock.getPath()).toReturn(blankFormMediaPath);
         Mockito.stub(savedFormMock.getUri()).toReturn(saveFormURI);
         odkForm = new ODKForm(blankFormMock, savedFormMock);
+        String deviceId = getValue(HH_PHONE_ID);
 
-
-        odkForm.open(new HouseholdMemberFormStrategy(householdMock), householdActivity, RequestCode.SURVEY.getCode());
+        odkForm.open(new HouseholdMemberFormStrategy(householdMock, deviceId), householdActivity, RequestCode.SURVEY.getCode());
 
         ShadowActivity.IntentForResult odkActivity = Robolectric.shadowOf(householdActivity).getNextStartedActivityForResult();
 
@@ -148,9 +150,9 @@ public class ODKFormTest extends TestCase {
         Mockito.stub(blankFormMock.getPath()).toReturn(blankFormMediaPath);
         Mockito.stub(blankFormMock.getUri()).toReturn(blankFormURI);
         odkForm = new ODKForm(blankFormMock, null);
+        String deviceId = getValue(HH_PHONE_ID);
 
-
-        odkForm.open(new HouseholdMemberFormStrategy(householdMock), householdActivity, RequestCode.SURVEY.getCode());
+        odkForm.open(new HouseholdMemberFormStrategy(householdMock, deviceId), householdActivity, RequestCode.SURVEY.getCode());
 
         ShadowActivity.IntentForResult odkActivity = Robolectric.shadowOf(householdActivity).getNextStartedActivityForResult();
 

--- a/src/test/java/com/onaio/steps/model/ODKForm/strategy/HouseholdMemberFormStrategyTest.java
+++ b/src/test/java/com/onaio/steps/model/ODKForm/strategy/HouseholdMemberFormStrategyTest.java
@@ -1,0 +1,120 @@
+package com.onaio.steps.model.ODKForm.strategy;
+
+import android.content.Intent;
+import android.net.Uri;
+
+import com.onaio.steps.activities.HouseholdActivity;
+import com.onaio.steps.helper.Constants;
+import com.onaio.steps.helper.DatabaseHelper;
+import com.onaio.steps.helper.FileUtil;
+import com.onaio.steps.model.Gender;
+import com.onaio.steps.model.Household;
+import com.onaio.steps.model.InterviewStatus;
+import com.onaio.steps.model.Member;
+import com.onaio.steps.model.ODKForm.IForm;
+import com.onaio.steps.model.ODKForm.ODKForm;
+import com.onaio.steps.model.RequestCode;
+import com.onaio.steps.model.ShadowDatabaseHelper;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Created by Jason Rogena - jrogena@ona.io on 29/09/2016.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(emulateSdk = 16, manifest = "src/main/AndroidManifest.xml",shadows = {ShadowDatabaseHelper.class})
+public class HouseholdMemberFormStrategyTest {
+    private FileUtil fileUtilMock;
+    private HouseholdActivity householdActivity;
+    private Member selectedMember;
+    private Household householdMock;
+    private ODKForm odkForm;
+    private IForm blankFormMock;
+
+    private final int HHID_KEY = 1;
+    private final String MEMBER_ID = "householdID-1";
+    private final String SURNAME = "surname";
+    private final String FIRST_NAME = "firstname";
+    private final Gender GENDER = Gender.Male;
+    private final int AGE = 28;
+    private final String DEVICE_ID = "test_dev_id";
+
+    @Before
+    public void Setup(){
+        stubHousehold();
+        stubFileUtil();
+
+        Intent intent = new Intent();
+        Mockito.stub(householdMock.getPhoneNumber()).toReturn("8050342");
+        Mockito.stub(householdMock.getComments()).toReturn("dummy comments");
+        intent.putExtra(Constants.HH_HOUSEHOLD,householdMock);
+
+        householdActivity = Robolectric.buildActivity(HouseholdActivity.class).withIntent(intent).create().get();
+        blankFormMock = Mockito.mock(IForm.class);
+    }
+
+    private void stubFileUtil() {
+        fileUtilMock = Mockito.mock(FileUtil.class);
+        Mockito.stub(fileUtilMock.withData(Mockito.any(String[].class))).toReturn(fileUtilMock);
+        Mockito.stub(fileUtilMock.withHeader(Mockito.any(String[].class))).toReturn(fileUtilMock);
+    }
+
+    private void stubHousehold() {
+        householdMock = Mockito.mock(Household.class);
+        selectedMember = new Member(HHID_KEY, SURNAME, FIRST_NAME, GENDER, AGE, householdMock, MEMBER_ID, false);
+        Mockito.stub(householdMock.getSelectedMember(Mockito.any(DatabaseHelper.class))).toReturn(selectedMember);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+    }
+
+    @Test
+    public void testSaveDataFile() throws IOException {
+        //mock launch ODK with the household member
+        String blankFormMediaPath = householdActivity.getFilesDir().getPath();
+        String householdName = "household name";
+        Uri blankFormURI = Uri.parse("uri");
+        Mockito.stub(householdMock.getName()).toReturn(householdName);
+        Mockito.stub(blankFormMock.getPath()).toReturn(blankFormMediaPath);
+        Mockito.stub(blankFormMock.getUri()).toReturn(blankFormURI);
+        odkForm = new ODKForm(blankFormMock, null);
+
+        odkForm.open(new HouseholdMemberFormStrategy(householdMock, DEVICE_ID), householdActivity, RequestCode.SURVEY.getCode());
+
+        Robolectric.shadowOf(householdActivity).getNextStartedActivityForResult();
+
+        //see if generated csv file has the required columns
+        File formMediaDir = new File(blankFormMediaPath);
+        String absolutePath = new File(formMediaDir, Constants.ODK_DATA_FILENAME).getAbsolutePath();
+        FileUtil fileUtil = new FileUtil();
+        List<String[]> lines = fileUtil.readFile(absolutePath);
+        String[] csvExpectedValues = new String[]{
+                String.valueOf(HHID_KEY),
+                null,
+                MEMBER_ID,
+                SURNAME,
+                FIRST_NAME,
+                String.valueOf(GENDER.getIntValue()),
+                String.valueOf(AGE),
+                null,
+                DEVICE_ID
+        };
+        for(String[] curLine : lines) {
+            for(int i = 0; i < csvExpectedValues.length; i++) {
+                if(csvExpectedValues[i] != null) {
+                    Assert.assertEquals(csvExpectedValues[i], curLine[i]);
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/com/onaio/steps/model/ODKForm/strategy/ParticipantFormStrategyTest.java
+++ b/src/test/java/com/onaio/steps/model/ODKForm/strategy/ParticipantFormStrategyTest.java
@@ -1,0 +1,109 @@
+package com.onaio.steps.model.ODKForm.strategy;
+
+import android.content.Intent;
+import android.net.Uri;
+
+import com.onaio.steps.activities.ParticipantActivity;
+import com.onaio.steps.helper.Constants;
+import com.onaio.steps.helper.FileUtil;
+import com.onaio.steps.model.Gender;
+import com.onaio.steps.model.InterviewStatus;
+import com.onaio.steps.model.ODKForm.IForm;
+import com.onaio.steps.model.ODKForm.ODKForm;
+import com.onaio.steps.model.Participant;
+import com.onaio.steps.model.RequestCode;
+import com.onaio.steps.model.ShadowDatabaseHelper;
+
+import junit.framework.Assert;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * Created by Jason Rogena - jrogena@ona.io on 29/09/2016.
+ */
+@RunWith(RobolectricTestRunner.class)
+@Config(emulateSdk = 16, manifest = "src/main/AndroidManifest.xml",shadows = {ShadowDatabaseHelper.class})
+public class ParticipantFormStrategyTest {
+    private FileUtil fileUtilMock;
+    private ParticipantActivity participantActivity;
+    private Participant participant;
+    private ODKForm odkForm;
+    private IForm blankFormMock;
+
+    private final String PARTICIPANT_ID = "participantID-1";
+    private final String SURNAME = "surname";
+    private final String FIRST_NAME = "firstname";
+    private final Gender GENDER = Gender.Male;
+    private final int AGE = 28;
+    private final String DEVICE_ID = "test_dev_id";
+    private final InterviewStatus INTERVIEW_STATUS = InterviewStatus.NOT_DONE;
+    private final String CREATED_AT = new SimpleDateFormat(Constants.DATE_FORMAT).format(new Date());
+
+    @Before
+    public void Setup(){
+        participant = new Participant(PARTICIPANT_ID, SURNAME, FIRST_NAME, GENDER, AGE, INTERVIEW_STATUS, CREATED_AT);
+        stubFileUtil();
+
+        Intent intent = new Intent();
+        intent.putExtra(Constants.PARTICIPANT, participant);
+
+        participantActivity = Robolectric.buildActivity(ParticipantActivity.class).withIntent(intent).create().get();
+        blankFormMock = Mockito.mock(IForm.class);
+    }
+
+    private void stubFileUtil() {
+        fileUtilMock = Mockito.mock(FileUtil.class);
+        Mockito.stub(fileUtilMock.withData(Mockito.any(String[].class))).toReturn(fileUtilMock);
+        Mockito.stub(fileUtilMock.withHeader(Mockito.any(String[].class))).toReturn(fileUtilMock);
+    }
+
+    @Test
+    public void testSaveDataFile() throws IOException {
+        //mock launch ODK with the participant
+        String blankFormMediaPath = participantActivity.getFilesDir().getPath();
+        Uri blankFormURI = Uri.parse("uri");
+        Mockito.stub(blankFormMock.getPath()).toReturn(blankFormMediaPath);
+        Mockito.stub(blankFormMock.getUri()).toReturn(blankFormURI);
+        odkForm = new ODKForm(blankFormMock, null);
+
+        odkForm.open(new ParticipantFormStrategy(participant, DEVICE_ID), participantActivity, RequestCode.SURVEY.getCode());
+
+        Robolectric.shadowOf(participantActivity).getNextStartedActivityForResult();
+
+        //see if generated csv file has the required columns
+        File formMediaDir = new File(blankFormMediaPath);
+        String absolutePath = new File(formMediaDir, Constants.ODK_DATA_FILENAME).getAbsolutePath();
+        FileUtil fileUtil = new FileUtil();
+        List<String[]> lines = fileUtil.readFile(absolutePath);
+        String[] csvExpectedValues = new String[]{
+                null,
+                null,
+                PARTICIPANT_ID,
+                SURNAME,
+                FIRST_NAME,
+                String.valueOf(GENDER.getIntValue()),
+                String.valueOf(AGE),
+                null,
+                DEVICE_ID
+        };
+        for(String[] curLine : lines) {
+            for(int i = 0; i < csvExpectedValues.length; i++) {
+                if(csvExpectedValues[i] != null) {
+                    Assert.assertEquals(csvExpectedValues[i], curLine[i]);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds the 'device_id' field in the pulldata CSV file generated when interviewing either household member or participant.

Will require pull request #46 to be merged first for tests can start passing.

Fix for issue #40 