### PR TITLE
Survey Status Codes

### DIFF
--- a/src/main/java/com/onaio/steps/activities/HouseholdActivity.java
+++ b/src/main/java/com/onaio/steps/activities/HouseholdActivity.java
@@ -29,6 +29,7 @@ import android.widget.AdapterView;
 import android.widget.TextView;
 
 import com.onaio.steps.R;
+import com.onaio.steps.handler.SelectedParticipantContainerHandler;
 import com.onaio.steps.handler.factories.HouseholdActivityFactory;
 import com.onaio.steps.handler.interfaces.IActivityResultHandler;
 import com.onaio.steps.handler.interfaces.IMenuHandler;
@@ -62,6 +63,14 @@ public class HouseholdActivity extends ListActivity {
         handleMembers();
         prepareCustomMenu();
         populateMessage();
+    }
+
+    @Override
+    public void onBackPressed() {
+        SelectedParticipantContainerHandler handler = new SelectedParticipantContainerHandler(this, household);
+        if(handler.shouldInactivate()) {
+            super.onBackPressed();
+        }
     }
 
     private void populateMessage() {

--- a/src/main/java/com/onaio/steps/adapters/HouseholdAdapter.java
+++ b/src/main/java/com/onaio/steps/adapters/HouseholdAdapter.java
@@ -96,7 +96,7 @@ public class HouseholdAdapter extends BaseAdapter{
         switch (householdAtPosition.getStatus()){
             case DONE: return R.mipmap.ic_household_list_done;
             case NOT_DONE: return R.mipmap.ic_household_list_not_done;
-            case NOT_SELECTED: return R.mipmap.ic_household_list_not_selected;
+            case SELECTION_NOT_DONE: return R.mipmap.ic_household_list_not_selected;
             case DEFERRED: return R.mipmap.ic_household_list_deferred;
             case INCOMPLETE: return R.mipmap.ic_household_list_incomplete;
             case INCOMPLETE_REFUSED: return R.mipmap.ic_household_list_refused;

--- a/src/main/java/com/onaio/steps/handler/SelectedParticipantContainerHandler.java
+++ b/src/main/java/com/onaio/steps/handler/SelectedParticipantContainerHandler.java
@@ -16,6 +16,7 @@
 
 package com.onaio.steps.handler;
 
+import android.app.ActionBar;
 import android.app.Activity;
 import android.view.View;
 
@@ -53,5 +54,13 @@ public class SelectedParticipantContainerHandler implements IMenuPreparer {
     public void activate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.VISIBLE);
+        //hide the go up button
+        ActionBar actionBar = activity.getActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeButtonEnabled(false); // disable the button
+            actionBar.setDisplayHomeAsUpEnabled(false); // remove the left caret
+            actionBar.setDisplayShowHomeEnabled(false); // remove the icon
+        }
+        //prevent the user from pressing the back button
     }
 }

--- a/src/main/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandler.java
@@ -36,7 +36,7 @@ import com.onaio.steps.model.ReElectReason;
 
 import java.util.List;
 
-import static com.onaio.steps.model.InterviewStatus.NOT_SELECTED;
+import static com.onaio.steps.model.InterviewStatus.SELECTION_NOT_DONE;
 
 public class CancelParticipantSelectionHandler implements IMenuPreparer,IMenuHandler {
 
@@ -111,7 +111,7 @@ public class CancelParticipantSelectionHandler implements IMenuPreparer,IMenuHan
 
     private void updateHousehold() {
         household.setSelectedMemberId(null);
-        household.setStatus(NOT_SELECTED);
+        household.setStatus(SELECTION_NOT_DONE);
         household.update(new DatabaseHelper(activity));
     }
 

--- a/src/main/java/com/onaio/steps/handler/actions/ExportHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/ExportHandler.java
@@ -197,7 +197,7 @@ public class ExportHandler implements IMenuHandler,IMenuPreparer {
     }
 
 
-    private void setStatus(Household household, Member member, ArrayList<String> row) {
+    public static void setStatus(Household household, Member member, ArrayList<String> row) {
         if(household.getSelectedMemberId() == null || household.getSelectedMemberId().equals("") || household.getSelectedMemberId().equals(String.valueOf(member.getId())))
             row.add(household.getStatus().toString());
         else {

--- a/src/main/java/com/onaio/steps/handler/actions/ExportHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/ExportHandler.java
@@ -48,7 +48,8 @@ import java.util.List;
 import static com.onaio.steps.helper.Constants.EXPORT_FIELDS;
 import static com.onaio.steps.helper.Constants.HH_PHONE_ID;
 import static com.onaio.steps.helper.Constants.HH_SURVEY_ID;
-import static com.onaio.steps.helper.Constants.SURVEY_NA;
+import static com.onaio.steps.helper.Constants.SURVEY_EMPTY_HH;
+import static com.onaio.steps.helper.Constants.SURVEY_NOT_SELECTED;
 
 public class ExportHandler implements IMenuHandler,IMenuPreparer {
 
@@ -170,7 +171,7 @@ public class ExportHandler implements IMenuHandler,IMenuPreparer {
             row.add(EMPTY_COLUMN);
             row.add(EMPTY_COLUMN);
             row.add(EMPTY_COLUMN);
-            row.add(SURVEY_NA);
+            row.add(SURVEY_EMPTY_HH);
             row.add(String.valueOf(reasons.size()));
             row.add(replaceCommas(StringUtils.join(reasons.toArray(), ';')));
             row.add(deviceId);
@@ -200,7 +201,7 @@ public class ExportHandler implements IMenuHandler,IMenuPreparer {
         if(household.getSelectedMemberId() == null || household.getSelectedMemberId().equals("") || household.getSelectedMemberId().equals(String.valueOf(member.getId())))
             row.add(household.getStatus().toString());
         else {
-            row.add(SURVEY_NA);
+            row.add(SURVEY_NOT_SELECTED);
         }
     }
 

--- a/src/main/java/com/onaio/steps/handler/actions/ImportHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/ImportHandler.java
@@ -112,7 +112,7 @@ public class ImportHandler implements IMenuHandler {
                 Household household = Household.find_by(db, householdName);
                 if(household == null){
                     String currentDate = new SimpleDateFormat(Constants.DATE_FORMAT, Locale.ENGLISH).format(new Date());
-                    household = new Household(householdName, phoneNumber, InterviewStatus.NOT_SELECTED, currentDate ,comments);
+                    household = new Household(householdName, phoneNumber, InterviewStatus.SELECTION_NOT_DONE, currentDate ,comments);
                     household.save(db);
                 }
                 //validate for members
@@ -121,7 +121,10 @@ public class ImportHandler implements IMenuHandler {
                     member = new Member(surname, firstName, Gender.valueOf(gender), Integer.parseInt(age), household, Boolean.getBoolean(deleted));
                     member.setMemberHouseholdId(memberHouseholdId);
                     member.save(db);
-                    if (!(surveyStatus.equals(Constants.SURVEY_NA) || surveyStatus.equals(InterviewStatus.NOT_SELECTED.toString()))) {
+                    if (!(surveyStatus.equals(Constants.SURVEY_NA)
+                            || surveyStatus.equals(Constants.SURVEY_EMPTY_HH)
+                            || surveyStatus.equals(Constants.SURVEY_NOT_SELECTED)
+                            || surveyStatus.equals(InterviewStatus.SELECTION_NOT_DONE.toString()))) {
                         household.setStatus(InterviewStatus.valueOf(surveyStatus));
                         household.setSelectedMemberId(String.valueOf(member.getId()));
                         household.update(db);

--- a/src/main/java/com/onaio/steps/handler/actions/SelectParticipantHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/SelectParticipantHandler.java
@@ -73,7 +73,7 @@ public class SelectParticipantHandler implements IMenuHandler, IMenuPreparer {
     @Override
     public boolean shouldInactivate() {
         boolean noMember = household.numberOfNonSelectedMembers(db) == 0;
-        boolean noSelection = household.getStatus() == InterviewStatus.NOT_SELECTED;
+        boolean noSelection = household.getStatus() == InterviewStatus.SELECTION_NOT_DONE;
         return noMember || !noSelection;
     }
 

--- a/src/main/java/com/onaio/steps/handler/activities/NewMemberActivityHandler.java
+++ b/src/main/java/com/onaio/steps/handler/activities/NewMemberActivityHandler.java
@@ -88,7 +88,7 @@ public class NewMemberActivityHandler implements IMenuHandler, IActivityResultHa
 
     @Override
     public boolean shouldInactivate() {
-        return !(household.getStatus().equals(InterviewStatus.NOT_SELECTED));
+        return !(household.getStatus().equals(InterviewStatus.SELECTION_NOT_DONE));
     }
 
     public void inactivate() {

--- a/src/main/java/com/onaio/steps/helper/Constants.java
+++ b/src/main/java/com/onaio/steps/helper/Constants.java
@@ -40,6 +40,8 @@ public class Constants {
     public static final String HEADER_GREEN = "#008148";
     public static final String TEXT_GREEN = "#53B257";
     public static final String SURVEY_NA = "NA";
+    public static final String SURVEY_EMPTY_HH = "EMPTY_HH";
+    public static final String SURVEY_NOT_SELECTED = "NOT_SELECTED";
 
 
     //Export related

--- a/src/main/java/com/onaio/steps/model/InterviewStatus.java
+++ b/src/main/java/com/onaio/steps/model/InterviewStatus.java
@@ -19,7 +19,7 @@ package com.onaio.steps.model;
 import java.util.HashMap;
 
 public enum InterviewStatus {
-    NOT_SELECTED(4),
+    SELECTION_NOT_DONE(4),
     INCOMPLETE(1),
     NOT_DONE(2),
     DONE(5),

--- a/src/main/java/com/onaio/steps/modelViewWrapper/HouseholdViewWrapper.java
+++ b/src/main/java/com/onaio/steps/modelViewWrapper/HouseholdViewWrapper.java
@@ -42,7 +42,7 @@ public class HouseholdViewWrapper {
         String currentDate = new SimpleDateFormat(Constants.DATE_FORMAT).format(new Date());
         EditText commentsView = (EditText) activity.findViewById(commentsViewId);
         String comments = commentsView.getText().toString();
-        return new Household(nameView.getText().toString(), phoneNumber, InterviewStatus.NOT_SELECTED, currentDate,comments);
+        return new Household(nameView.getText().toString(), phoneNumber, InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
     }
 
     public Household updateHousehold(Household household, int numberViewId, int commentsViewId) {

--- a/src/test/java/com/onaio/steps/activities/MemberActivityTest.java
+++ b/src/test/java/com/onaio/steps/activities/MemberActivityTest.java
@@ -129,7 +129,7 @@ public class MemberActivityTest {
     @Test
     public void ShouldActivateMenuOptionsForNotSelectedStatus() {
         intent.putExtra(Constants.HH_MEMBER, member);
-        Mockito.stub(household.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(household.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
         memberActivity = memberActivityController.withIntent(intent).create().get();
 
         Menu menu = Mockito.mock(Menu.class);

--- a/src/test/java/com/onaio/steps/activities/NewMemberActivityTest.java
+++ b/src/test/java/com/onaio/steps/activities/NewMemberActivityTest.java
@@ -56,7 +56,7 @@ public class NewMemberActivityTest {
 
     @Before
     public void setup() {
-        household = new Household("2", "Any HouseholdName", "123456789", "", InterviewStatus.NOT_SELECTED, currentDate, "Dummy comments");
+        household = new Household("2", "Any HouseholdName", "123456789", "", InterviewStatus.SELECTION_NOT_DONE, currentDate, "Dummy comments");
         Intent intent = new Intent();
         intent.putExtra(Constants.HH_HOUSEHOLD, household);
         newMemberActivity = Robolectric.buildActivity(NewMemberActivity.class).withIntent(intent)

--- a/src/test/java/com/onaio/steps/handler/SelectedParticipantContainerHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/SelectedParticipantContainerHandlerTest.java
@@ -58,7 +58,7 @@ public class SelectedParticipantContainerHandlerTest {
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         assertTrue(selectedParticipantContainerHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandlerTest.java
@@ -67,7 +67,7 @@ public class CancelParticipantSelectionHandlerTest {
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         assertTrue(selectionHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/actions/DeferredHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/DeferredHandlerTest.java
@@ -80,7 +80,7 @@ public class DeferredHandlerTest {
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         assertTrue(deferredHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/actions/ExportHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/ExportHandlerTest.java
@@ -84,7 +84,7 @@ public class ExportHandlerTest {
 //    @Test
 //    public void ShouldInactivateEditOptionForSelectedMember(){
 //        ArrayList<Household> households = Mockito.mock(ArrayList.class);
-//        Household household = new Household("12", "name", "321", "1", InterviewStatus.NOT_SELECTED, "12-12-2001");
+//        Household household = new Household("12", "name", "321", "1", InterviewStatus.SELECTION_NOT_DONE, "12-12-2001");
 //
 //        households.add(household);
 //        DatabaseHelper dbMock = Mockito.mock(DatabaseHelper.class);

--- a/src/test/java/com/onaio/steps/handler/actions/ExportHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/ExportHandlerTest.java
@@ -19,7 +19,6 @@ package com.onaio.steps.handler.actions;
 import android.content.Context;
 import android.content.Intent;
 import android.telephony.TelephonyManager;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -188,17 +187,40 @@ public class ExportHandlerTest {
                 null,
                 "0",
                 deviceIMEI,
-                createdAt
+                createdAt,
+                "0"
         };
         for(String[] curLine : lines) {
             for(int i = 0; i < expectedValues.length; i++) {
                 if(expectedValues[i] != null) {
-                    Log.d("ExportTest", "Expected = "+expectedValues[i]);
-                    Log.d("ExportTest", "Actual = "+curLine[i]);
                     Assert.assertEquals(expectedValues[i], curLine[i]);
                 }
             }
         }
+    }
+
+    /**
+     * This method tests whether the setStatus method works correctly with:
+     *  - a member that is not the selected member in the household gets the NOT_SELECTED status
+     *  - a member that is the selected member in the household inherits the household's status
+     */
+    @Test
+    public void testSetStatus() {
+        int selectedMemberId = 1;
+        Household householdMock = Mockito.mock(Household.class);
+        Mockito.stub(householdMock.getSelectedMemberId()).toReturn(String.valueOf(selectedMemberId));
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
+        Member member1 = Mockito.mock(Member.class);
+        Mockito.stub(member1.getId()).toReturn(1);
+        Member member2 = Mockito.mock(Member.class);
+        Mockito.stub(member2.getId()).toReturn(2);
+
+        ArrayList<String> rows = new ArrayList<>();
+        ExportHandler.setStatus(householdMock, member1, rows);
+        ExportHandler.setStatus(householdMock, member2, rows);
+
+        Assert.assertEquals(rows.get(0), householdMock.getStatus().toString());
+        Assert.assertEquals(rows.get(1), Constants.SURVEY_NOT_SELECTED);
     }
 
 }

--- a/src/test/java/com/onaio/steps/handler/actions/ImportHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/ImportHandlerTest.java
@@ -109,7 +109,7 @@ public class ImportHandlerTest {
 //        rowData.add("23");
 //        rowData.add(Constants.MALE);
 //        rowData.add(String.valueOf(true));
-//        rowData.add(String.valueOf(InterviewStatus.NOT_SELECTED));
+//        rowData.add(String.valueOf(InterviewStatus.SELECTION_NOT_DONE));
 //        rowData.add("2");
 //        rowData.add("some reason;some other reason");
 //        rows.add(rowData.toArray(new String[]{}));

--- a/src/test/java/com/onaio/steps/handler/actions/RefusedHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/RefusedHandlerTest.java
@@ -79,7 +79,7 @@ public class RefusedHandlerTest {
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         assertTrue(refusedHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/actions/SelectParticipantHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/SelectParticipantHandlerTest.java
@@ -64,7 +64,7 @@ public class SelectParticipantHandlerTest {
     @Before
     public void Setup(){
         householdMock = mock(Household.class);
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
         Mockito.stub(householdMock.getPhoneNumber()).toReturn("8050342");
         Mockito.stub(householdMock.getComments()).toReturn("dummy comments");
 
@@ -91,7 +91,7 @@ public class SelectParticipantHandlerTest {
 
     @Test
     public void ShouldNotifyUserBeforeSelection(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
         Button buttonMock = Mockito.mock(Button.class);
         stub(androidDialogMock.findViewById(R.id.confirm)).toReturn(buttonMock);
         stub(androidDialogMock.findViewById(R.id.cancel)).toReturn(buttonMock);
@@ -154,7 +154,7 @@ public class SelectParticipantHandlerTest {
     @Test
     public void ShouldActivateWhenHouseholdStatusIsNotSelected(){
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         Assert.assertFalse(selectParticipantHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/actions/SelectedParticipantActionsHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/SelectedParticipantActionsHandlerTest.java
@@ -60,7 +60,7 @@ public class SelectedParticipantActionsHandlerTest {
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         assertTrue(selectedParticipantActionsHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/actions/TakeSurveyHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/TakeSurveyHandlerTest.java
@@ -76,7 +76,7 @@ public class TakeSurveyHandlerTest {
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         Assert.assertTrue(takeSurveyHandler.shouldInactivate());
     }

--- a/src/test/java/com/onaio/steps/handler/activities/EditMemberActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/EditMemberActivityHandlerTest.java
@@ -108,7 +108,7 @@ public class EditMemberActivityHandlerTest {
     @Test
     public void ShouldInactivateEditOptionForSelectedMember(){
         Menu menuMock = Mockito.mock(Menu.class);
-        Household household = new Household("1234", "any name", "123456789", "1", InterviewStatus.NOT_SELECTED, "","Dummy comments");
+        Household household = new Household("1234", "any name", "123456789", "1", InterviewStatus.SELECTION_NOT_DONE, "","Dummy comments");
         Mockito.stub(memberMock.getHousehold()).toReturn(household);
         Mockito.stub(memberMock.getId()).toReturn(1);
 

--- a/src/test/java/com/onaio/steps/handler/activities/EditParticipantActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/EditParticipantActivityHandlerTest.java
@@ -101,7 +101,7 @@ public class EditParticipantActivityHandlerTest {
     @Test
     public void ShouldNotInactivateWhenParticipantIsSelected(){
         Menu menuMock = Mockito.mock(Menu.class);
-        Mockito.stub(participant.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(participant.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
         Assert.assertFalse(editParticipantActivityHandler.withMenu(menuMock).shouldInactivate());
     }
 

--- a/src/test/java/com/onaio/steps/handler/activities/HouseholdActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/HouseholdActivityHandlerTest.java
@@ -55,7 +55,7 @@ public class HouseholdActivityHandlerTest {
 
     @Test
     public void ShouldStartNewMemberActivityIfHouseholdIsNotNull(){
-        household = new Household("2", "Any HouseholdName", "123456789", "", InterviewStatus.NOT_SELECTED, currentDate,"Dummy comments");
+        household = new Household("2", "Any HouseholdName", "123456789", "", InterviewStatus.SELECTION_NOT_DONE, currentDate,"Dummy comments");
         householdActivityHandler = new HouseholdActivityHandler(householdListActivity, household);
         householdActivityHandler.open();
 

--- a/src/test/java/com/onaio/steps/handler/activities/MemberActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/MemberActivityHandlerTest.java
@@ -57,7 +57,7 @@ public class MemberActivityHandlerTest {
 
     @Test
     public void ShouldStartMemberActivityWhenMemberIsNotNull(){
-        Household household = new Household("2", "Any HouseholdName", "123456789", "", InterviewStatus.NOT_SELECTED, currentDate,"Dummy comments");
+        Household household = new Household("2", "Any HouseholdName", "123456789", "", InterviewStatus.SELECTION_NOT_DONE, currentDate,"Dummy comments");
         member = new Member("Rana", "Nikhil", Gender.Female, 20, household, false);
         memberActivityHandler = new MemberActivityHandler(householdActivity, member);
 

--- a/src/test/java/com/onaio/steps/handler/activities/NewHouseholdActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/NewHouseholdActivityHandlerTest.java
@@ -128,7 +128,7 @@ public class NewHouseholdActivityHandlerTest {
     @Test
     public void ShouldHandleResultAndStartHouseholdActivityForResultCodeOk(){
         Intent intent = new Intent();
-        Household name = new Household("name", "123321412312", InterviewStatus.NOT_SELECTED, "123","Dummy comments");
+        Household name = new Household("name", "123321412312", InterviewStatus.SELECTION_NOT_DONE, "123","Dummy comments");
         name.save(new DatabaseHelper(householdListActivity));
         intent.putExtra(Constants.HH_HOUSEHOLD,name);
         HouseholdAdapter householdAdapterMock = Mockito.mock(HouseholdAdapter.class);

--- a/src/test/java/com/onaio/steps/handler/activities/NewMemberActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/NewMemberActivityHandlerTest.java
@@ -86,7 +86,7 @@ public class NewMemberActivityHandlerTest {
 
     @Test
     public void ShouldStartNewMemberActivityIfHouseholdIsNotNullAndHouseholdSurveyIsNotSelected() {
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
         newMemberActivityHandler.open();
 

--- a/src/test/java/com/onaio/steps/handler/factories/HouseholdActivityFactoryTest.java
+++ b/src/test/java/com/onaio/steps/handler/factories/HouseholdActivityFactoryTest.java
@@ -61,7 +61,7 @@ public class HouseholdActivityFactoryTest extends TestCase {
 
     @Before
     public void Setup(){
-        household = new Household("name", "123", InterviewStatus.NOT_SELECTED, "12-12-2015","Dummy comments");
+        household = new Household("name", "123", InterviewStatus.SELECTION_NOT_DONE, "12-12-2015","Dummy comments");
         Intent intent = new Intent().putExtra(Constants.HH_HOUSEHOLD, household);
         activity = Robolectric.buildActivity(HouseholdActivity.class).withIntent(intent).create().get();
     }

--- a/src/test/java/com/onaio/steps/handler/factories/MemberActivityFactoryTest.java
+++ b/src/test/java/com/onaio/steps/handler/factories/MemberActivityFactoryTest.java
@@ -54,7 +54,7 @@ public class MemberActivityFactoryTest extends TestCase {
 
     @Before
     public void Setup(){
-        household = new Household("name", "123", InterviewStatus.NOT_SELECTED, "12-12-2015","Dummy comments");
+        household = new Household("name", "123", InterviewStatus.SELECTION_NOT_DONE, "12-12-2015","Dummy comments");
         member = new Member(1,"surname", "firstname", Gender.Male, 23, household, "",false);
         Intent intent = new Intent().putExtra(Constants.HH_MEMBER, member);
         memberActivity = Robolectric.buildActivity(MemberActivity.class).withIntent(intent).create().get();

--- a/src/test/java/com/onaio/steps/model/HouseholdTest.java
+++ b/src/test/java/com/onaio/steps/model/HouseholdTest.java
@@ -46,7 +46,7 @@ import static junit.framework.Assert.*;
 @Config(emulateSdk = 16, manifest = "src/main/AndroidManifest.xml",shadows = {ShadowDatabaseHelper.class})
 public class HouseholdTest {
 
-    private final InterviewStatus interviewStatus = InterviewStatus.NOT_SELECTED;
+    private final InterviewStatus interviewStatus = InterviewStatus.SELECTION_NOT_DONE;
     private String currentDate = new SimpleDateFormat(Constants.DATE_FORMAT).format(new Date());
     @Mock
     private DatabaseHelper db;
@@ -140,7 +140,7 @@ public class HouseholdTest {
     @Test
     public void ShouldSortTheHouseholdsByStatus(){
         ArrayList<Household> households = new ArrayList<Household>();
-        households.add(new Household("name 1","123", InterviewStatus.NOT_SELECTED,"12-12-2014",""));
+        households.add(new Household("name 1","123", InterviewStatus.SELECTION_NOT_DONE,"12-12-2014",""));
         households.add(new Household("name 2","123", InterviewStatus.DEFERRED,"12-12-2014",""));
         households.add(new Household("name 3","123", InterviewStatus.DONE,"12-12-2014",""));
         households.add(new Household("name 4","123", InterviewStatus.INCOMPLETE,"12-12-2014",""));
@@ -187,7 +187,7 @@ public class HouseholdTest {
     @Test
     public void ShouldGetNonDeletedNumberOfMembersFromDatabase(){
         int numberOfMembers = 2;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
 
         assertEquals(numberOfMembers, household.numberOfNonDeletedMembers(db));
@@ -199,7 +199,7 @@ public class HouseholdTest {
     public void ShouldGetUnselectedNumberOfMembersFromDatabaseWhenThereIsSelectedMember(){
         int numberOfMembers = 2;
         String selectedMemberId = "3";
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber, selectedMemberId, InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber, selectedMemberId, InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
 
         assertEquals(numberOfMembers, household.numberOfNonSelectedMembers(db));
@@ -210,7 +210,7 @@ public class HouseholdTest {
     @Test
     public void ShouldGetNonDeletedMembersForUnselectedNumberOfMembersFromDatabaseWhenThereIsNoSelectedMember(){
         int numberOfMembers = 2;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,null, InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,null, InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
 
         assertEquals(numberOfMembers, household.numberOfNonSelectedMembers(db));
@@ -221,7 +221,7 @@ public class HouseholdTest {
     @Test
     public void ShouldGetAllNumberOfMembersFromDatabase(){
         int numberOfMembers = 1;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
 
         assertEquals(numberOfMembers, household.numberOfMembers(db));
@@ -233,7 +233,7 @@ public class HouseholdTest {
     public void ShouldGetAllNonDeletedMember(){
         long memberId = 1L;
         int numberOfMembers = 1;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
         new CursorStub(cursor).stubCursorForMember(memberId, memberFamilyName, memberFirstName, memberGender, String.valueOf(memberAge), String.valueOf(householdId), Member.NOT_DELETED_INT, householdName + "-1");
 
@@ -249,7 +249,7 @@ public class HouseholdTest {
         long memberId = 1L;
         int numberOfMembers = 1;
         String selectedMemberId = "2";
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber, selectedMemberId, InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber, selectedMemberId, InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
         new CursorStub(cursor).stubCursorForMember(memberId, memberFamilyName, memberFirstName, memberGender, String.valueOf(memberAge), String.valueOf(householdId), Member.NOT_DELETED_INT, householdName + "-1");
 
@@ -264,7 +264,7 @@ public class HouseholdTest {
     public void ShouldGetAllUnDeletedMembersForUnSelectedMembersWhenThereIsNoSelectedMember(){
         long memberId = 1L;
         int numberOfMembers = 1;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,null, InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,null, InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
         new CursorStub(cursor).stubCursorForMember(memberId, memberFamilyName, memberFirstName, memberGender, String.valueOf(memberAge), String.valueOf(householdId), Member.NOT_DELETED_INT, householdName + "-1");
 
@@ -279,7 +279,7 @@ public class HouseholdTest {
     public void ShouldGetAllMember(){
         long memberId = 1L;
         int numberOfMembers = 1;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
         new CursorStub(cursor).stubCursorForMember(memberId,memberFamilyName,memberFirstName,memberGender,String.valueOf(memberAge),String.valueOf(householdId), Member.DELETED_INT, householdName + "-1");
 
@@ -294,7 +294,7 @@ public class HouseholdTest {
     public void ShouldFindTheMemberById(){
         long memberId = 1L;
         int numberOfMembers = 1;
-        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.NOT_SELECTED, currentDate,comments);
+        Household household = new Household(String.valueOf(householdId), householdName, phoneNumber,"", InterviewStatus.SELECTION_NOT_DONE, currentDate,comments);
         stubDbForMember(numberOfMembers);
         new CursorStub(cursor).stubCursorForMember(memberId, memberFamilyName, memberFirstName, memberGender, String.valueOf(memberAge), String.valueOf(householdId), Member.NOT_DELETED_INT, householdName + "-1");
 

--- a/src/test/java/com/onaio/steps/model/MemberTest.java
+++ b/src/test/java/com/onaio/steps/model/MemberTest.java
@@ -60,7 +60,7 @@ public class MemberTest {
         db = Mockito.mock(DatabaseHelper.class);
         cursor = Mockito.mock(Cursor.class);
         String phoneNumber = "123456789";
-        household = new Household(householdId, householdName, phoneNumber,"", InterviewStatus.NOT_SELECTED, currentDate, comments);
+        household = new Household(householdId, householdName, phoneNumber,"", InterviewStatus.SELECTION_NOT_DONE, currentDate, comments);
     }
 
     @Test

--- a/src/test/java/com/onaio/steps/model/ODKForm/ODKFormTest.java
+++ b/src/test/java/com/onaio/steps/model/ODKForm/ODKFormTest.java
@@ -176,7 +176,7 @@ public class ODKFormTest extends TestCase {
         householdMock = Mockito.mock(Household.class);
         selectedMember = new Member(1, "surname", "firstName", Gender.Male, 28, householdMock, "householdID-1", false);
         Mockito.stub(householdMock.getSelectedMember(Mockito.any(DatabaseHelper.class))).toReturn(selectedMember);
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
     }
 
     private String getValue(String key) {

--- a/src/test/java/com/onaio/steps/model/ODKForm/strategy/HouseholdMemberFormStrategyTest.java
+++ b/src/test/java/com/onaio/steps/model/ODKForm/strategy/HouseholdMemberFormStrategyTest.java
@@ -75,7 +75,7 @@ public class HouseholdMemberFormStrategyTest {
         householdMock = Mockito.mock(Household.class);
         selectedMember = new Member(HHID_KEY, SURNAME, FIRST_NAME, GENDER, AGE, householdMock, MEMBER_ID, false);
         Mockito.stub(householdMock.getSelectedMember(Mockito.any(DatabaseHelper.class))).toReturn(selectedMember);
-        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_SELECTED);
+        Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
     }
 
     @Test

--- a/src/test/java/com/onaio/steps/model/ReElectReasonTest.java
+++ b/src/test/java/com/onaio/steps/model/ReElectReasonTest.java
@@ -47,7 +47,7 @@ public class ReElectReasonTest {
         db = Mockito.mock(DatabaseHelper.class);
         String date = new SimpleDateFormat(Constants.DATE_FORMAT).format(new Date());
         reason = new String(" ");
-        household = new Household("1", "Any Household", "123456789", "", InterviewStatus.NOT_SELECTED, date, "Dummy comments");
+        household = new Household("1", "Any Household", "123456789", "", InterviewStatus.SELECTION_NOT_DONE, date, "Dummy comments");
         reElectReason = new ReElectReason(reason, household);
     }
 

--- a/src/test/java/com/onaio/steps/modelViewWrapper/HouseholdViewWrapperTest.java
+++ b/src/test/java/com/onaio/steps/modelViewWrapper/HouseholdViewWrapperTest.java
@@ -70,7 +70,7 @@ public class HouseholdViewWrapperTest {
         commentsView.setText("");
         Household household = householdViewWrapper.getHousehold(R.id.generated_household_id, R.id.household_number,R.id.household_comments);
         assertTrue(household.getName().equals("new name"));
-        assertTrue(household.getStatus().equals(InterviewStatus.NOT_SELECTED));
+        assertTrue(household.getStatus().equals(InterviewStatus.SELECTION_NOT_DONE));
     }
 
     @Test
@@ -86,7 +86,7 @@ public class HouseholdViewWrapperTest {
         assertTrue(household.getName().equals("new name"));
         assertTrue(household.getPhoneNumber().equals("123456789"));
         assertEquals("Dummy Comments", household.getComments());
-        assertTrue(household.getStatus().equals(InterviewStatus.NOT_SELECTED));
+        assertTrue(household.getStatus().equals(InterviewStatus.SELECTION_NOT_DONE));
 
     }
 

--- a/src/test/java/com/onaio/steps/modelViewWrapper/MemberViewWrapperTest.java
+++ b/src/test/java/com/onaio/steps/modelViewWrapper/MemberViewWrapperTest.java
@@ -71,7 +71,7 @@ public class MemberViewWrapperTest {
         memberViewWrapper = new MemberViewWrapper(newMemberActivity);
         date = new SimpleDateFormat(Constants.DATE_FORMAT).format(new Date());
         error_string = getStringValue(R.string.invalid) + " %s, " + getStringValue(R.string.fill_correct_message) + " %s";
-        household = new Household("1", "Any Household", "123456789", "", InterviewStatus.NOT_SELECTED, date, "Dummy comments");
+        household = new Household("1", "Any Household", "123456789", "", InterviewStatus.SELECTION_NOT_DONE, date, "Dummy comments");
         anotherMember = new Member("some surname","firstName",Gender.Female, 22, household, false);
         setValue(Constants.HH_MIN_AGE, "18");
         setValue(Constants.HH_MAX_AGE, "70");


### PR DESCRIPTION
Changes the status codes as specified in the issue notes. Also disables the back button in the household page (after a member has already been chosen for the survey)

Fixes issue #42 