### PR TITLE
Cancel Button In Authentication Dialog

### DIFF
--- a/src/main/java/com/onaio/steps/helper/Constants.java
+++ b/src/main/java/com/onaio/steps/helper/Constants.java
@@ -70,5 +70,5 @@ public class Constants {
     public static final String SETTINGS_PASSWORD_HASH = "settings_password_hash";
     public static final String SETTINGS_AUTH_TIME = "settings_auth_time";
 
-    public static final long SETTINGS_AUTH_TIMEOUT = 30000;//the number of milliseconds after authentication in the settings screen before authentication can be asked
+    public static final long SETTINGS_AUTH_TIMEOUT = 60000;//the number of milliseconds after authentication in the settings screen before authentication can be asked
 }

--- a/src/main/java/com/onaio/steps/orchestrators/FlowOrchestrator.java
+++ b/src/main/java/com/onaio/steps/orchestrators/FlowOrchestrator.java
@@ -82,7 +82,7 @@ public class FlowOrchestrator {
     }
 
     private void onAuthSuccessful(FlowType flowType) {
-        LinearLayout settingsLayout = (LinearLayout) activity.findViewById(R.id.settings);
+        LinearLayout settingsLayout = (LinearLayout) activity.findViewById(R.id.settings_layout);
         settingsLayout.setVisibility(View.VISIBLE);
         getFlow(flowType).prepareSettingScreen();
     }

--- a/src/main/res/layout/dialog_auth.xml
+++ b/src/main/res/layout/dialog_auth.xml
@@ -32,12 +32,12 @@
         android:layout_margin="10dp"/>
     <TextView
         android:id="@+id/togglePasswordVisibility"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="10dp"
         android:textColor="#499F72"
         android:text="@string/show_password"
-        android:layout_gravity="center_vertical|right"/>
+        android:gravity="center_vertical|right"/>
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"

--- a/src/main/res/layout/settings.xml
+++ b/src/main/res/layout/settings.xml
@@ -16,11 +16,11 @@
   -->
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/settings"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <LinearLayout
+        android:id="@+id/settings"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/white"

--- a/src/main/res/layout/settings.xml
+++ b/src/main/res/layout/settings.xml
@@ -15,12 +15,12 @@
   ~ limitations under the License.
   -->
 
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView android:id="@+id/settings" xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <LinearLayout
-        android:id="@+id/settings"
+        android:id="@+id/settings_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@android:color/white"

--- a/src/test/java/com/onaio/steps/helper/AuthDialogTest.java
+++ b/src/test/java/com/onaio/steps/helper/AuthDialogTest.java
@@ -60,13 +60,13 @@ public class AuthDialogTest {
         //test with no time in SharedPreferences
         assertTrue(authDialog.needsAuth());
 
-        //test with a time that is less than 30sec
-        long lastAuthTime1 = Calendar.getInstance().getTimeInMillis() - 20000;
+        //test with a time that is less than 1 min
+        long lastAuthTime1 = Calendar.getInstance().getTimeInMillis() - 40000;
         KeyValueStoreFactory.instance(settingsActivity).putString(SETTINGS_AUTH_TIME, String.valueOf(lastAuthTime1));
         assertFalse(authDialog.needsAuth());
 
-        //test with a time that is greater than the 30sec timeout
-        long lastAuthTime2 = Calendar.getInstance().getTimeInMillis() - 40000;
+        //test with a time that is greater than the 1 min timeout
+        long lastAuthTime2 = Calendar.getInstance().getTimeInMillis() - 65000;
         KeyValueStoreFactory.instance(settingsActivity).putString(SETTINGS_AUTH_TIME, String.valueOf(lastAuthTime2));
         assertTrue(authDialog.needsAuth());
     }


### PR DESCRIPTION
Fixes whatever bug was causing the cancel button to shift downwards when the 'show password' link is clicked in the authentication dialog shown on the settings screen

This pull request has changes from pull request #65 

Fix for issue #62 