### PR TITLE
Back Button In HouseholdActivity

### DIFF
--- a/src/main/java/com/onaio/steps/activities/BaseListActivity.java
+++ b/src/main/java/com/onaio/steps/activities/BaseListActivity.java
@@ -97,8 +97,8 @@ public abstract class BaseListActivity extends ListActivity{
     public boolean onPrepareOptionsMenu(Menu menu) {
         List<IMenuPreparer> menuItemHandlers = getMenuPreparer(menu);
         for(IMenuPreparer handler:menuItemHandlers)
-            if(handler.shouldInactivate())
-                handler.inactivate();
+            if(handler.shouldDeactivate())
+                handler.deactivate();
             else
                 handler.activate();
         super.onPrepareOptionsMenu(menu);

--- a/src/main/java/com/onaio/steps/activities/HouseholdActivity.java
+++ b/src/main/java/com/onaio/steps/activities/HouseholdActivity.java
@@ -68,7 +68,7 @@ public class HouseholdActivity extends ListActivity {
     @Override
     public void onBackPressed() {
         HouseholdActivityBackButtonPreparer handler = new HouseholdActivityBackButtonPreparer(this, household);
-        if(!handler.shouldInactivate()) {
+        if(!handler.shouldDeactivate()) {
             super.onBackPressed();
         }
     }
@@ -169,8 +169,8 @@ public class HouseholdActivity extends ListActivity {
     private void prepareCustomMenu() {
         List<IMenuPreparer> customMenus = HouseholdActivityFactory.getCustomMenuPreparer(this, household);
         for(IMenuPreparer customMenu:customMenus)
-            if(customMenu.shouldInactivate())
-                customMenu.inactivate();
+            if(customMenu.shouldDeactivate())
+                customMenu.deactivate();
             else
                 customMenu.activate();
     }

--- a/src/main/java/com/onaio/steps/activities/HouseholdActivity.java
+++ b/src/main/java/com/onaio/steps/activities/HouseholdActivity.java
@@ -29,7 +29,7 @@ import android.widget.AdapterView;
 import android.widget.TextView;
 
 import com.onaio.steps.R;
-import com.onaio.steps.handler.SelectedParticipantContainerHandler;
+import com.onaio.steps.handler.HouseholdActivityBackButtonPreparer;
 import com.onaio.steps.handler.factories.HouseholdActivityFactory;
 import com.onaio.steps.handler.interfaces.IActivityResultHandler;
 import com.onaio.steps.handler.interfaces.IMenuHandler;
@@ -67,8 +67,8 @@ public class HouseholdActivity extends ListActivity {
 
     @Override
     public void onBackPressed() {
-        SelectedParticipantContainerHandler handler = new SelectedParticipantContainerHandler(this, household);
-        if(handler.shouldInactivate()) {
+        HouseholdActivityBackButtonPreparer handler = new HouseholdActivityBackButtonPreparer(this, household);
+        if(!handler.shouldInactivate()) {
             super.onBackPressed();
         }
     }

--- a/src/main/java/com/onaio/steps/activities/MemberActivity.java
+++ b/src/main/java/com/onaio/steps/activities/MemberActivity.java
@@ -95,8 +95,8 @@ public class MemberActivity extends Activity {
     public boolean onPrepareOptionsMenu(Menu menu) {
         List<IMenuPreparer> menuItemHandlers = MemberActivityFactory.getMenuPreparer(this, member,menu);
         for(IMenuPreparer handler:menuItemHandlers)
-            if(handler.shouldInactivate())
-                handler.inactivate();
+            if(handler.shouldDeactivate())
+                handler.deactivate();
         super.onPrepareOptionsMenu(menu);
         return true;
     }

--- a/src/main/java/com/onaio/steps/activities/ParticipantActivity.java
+++ b/src/main/java/com/onaio/steps/activities/ParticipantActivity.java
@@ -138,8 +138,8 @@ public class ParticipantActivity extends Activity{
     private void prepareCustomMenu() {
         List<IMenuPreparer> customMenus = ParticipantActivityFactory.getCustomMenuPreparer(this, participant);
         for(IMenuPreparer customMenu:customMenus)
-            if(customMenu.shouldInactivate())
-                customMenu.inactivate();
+            if(customMenu.shouldDeactivate())
+                customMenu.deactivate();
             else
                 customMenu.activate();
     }
@@ -148,8 +148,8 @@ public class ParticipantActivity extends Activity{
     public boolean onPrepareOptionsMenu(Menu menu) {
         List<IMenuPreparer> menuItemHandlers =ParticipantActivityFactory.getMenuPreparer(this, participant, menu);
         for(IMenuPreparer handler:menuItemHandlers)
-            if(handler.shouldInactivate())
-                handler.inactivate();
+            if(handler.shouldDeactivate())
+                handler.deactivate();
         super.onPrepareOptionsMenu(menu);
         return true;
     }

--- a/src/main/java/com/onaio/steps/handler/HouseholdActivityBackButtonPreparer.java
+++ b/src/main/java/com/onaio/steps/handler/HouseholdActivityBackButtonPreparer.java
@@ -16,20 +16,25 @@
 
 package com.onaio.steps.handler;
 
+import android.app.ActionBar;
 import android.app.Activity;
-import android.view.View;
+import android.util.Log;
 
-import com.onaio.steps.R;
 import com.onaio.steps.handler.interfaces.IMenuPreparer;
 import com.onaio.steps.model.Household;
 import com.onaio.steps.model.InterviewStatus;
 
-public class SelectedParticipantContainerHandler implements IMenuPreparer {
-    private final int MENU_ID = R.id.selected_participant;
+/**
+ * This preparer determines whether the back button in the Household Activity should be shown
+ *
+ * Created by Jason Rogena - jrogena@ona.io on 21/10/2016.
+ */
+
+public class HouseholdActivityBackButtonPreparer implements IMenuPreparer {
     private Activity activity;
     private Household household;
 
-    public SelectedParticipantContainerHandler(Activity activity, Household household) {
+    public HouseholdActivityBackButtonPreparer(Activity activity, Household household) {
         this.activity = activity;
         this.household = household;
     }
@@ -38,20 +43,26 @@ public class SelectedParticipantContainerHandler implements IMenuPreparer {
     public boolean shouldInactivate() {
         InterviewStatus status = household.getStatus();
         boolean notDone = status.equals(InterviewStatus.NOT_DONE);
-        boolean deferred = status.equals(InterviewStatus.DEFERRED);
-        boolean incomplete = status.equals(InterviewStatus.INCOMPLETE);
-        return !notDone && !deferred && !incomplete;
+        return notDone;
     }
 
     @Override
     public void inactivate() {
-        View item = activity.findViewById(MENU_ID);
-        item.setVisibility(View.GONE);
+        //hide the go up button
+        ActionBar actionBar = activity.getActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeButtonEnabled(false); // disable the button
+            actionBar.setDisplayShowHomeEnabled(false); // remove the icon
+        }
     }
 
     @Override
     public void activate() {
-        View item = activity.findViewById(MENU_ID);
-        item.setVisibility(View.VISIBLE);
+        //show the go up button
+        ActionBar actionBar = activity.getActionBar();
+        if (actionBar != null) {
+            actionBar.setHomeButtonEnabled(true); // enable the button
+            actionBar.setDisplayShowHomeEnabled(true); // add the icon
+        }
     }
 }

--- a/src/main/java/com/onaio/steps/handler/HouseholdActivityBackButtonPreparer.java
+++ b/src/main/java/com/onaio/steps/handler/HouseholdActivityBackButtonPreparer.java
@@ -40,14 +40,14 @@ public class HouseholdActivityBackButtonPreparer implements IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         InterviewStatus status = household.getStatus();
         boolean notDone = status.equals(InterviewStatus.NOT_DONE);
         return notDone;
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         //hide the go up button
         ActionBar actionBar = activity.getActionBar();
         if (actionBar != null) {

--- a/src/main/java/com/onaio/steps/handler/SelectedParticipantContainerHandler.java
+++ b/src/main/java/com/onaio/steps/handler/SelectedParticipantContainerHandler.java
@@ -35,7 +35,7 @@ public class SelectedParticipantContainerHandler implements IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         InterviewStatus status = household.getStatus();
         boolean notDone = status.equals(InterviewStatus.NOT_DONE);
         boolean deferred = status.equals(InterviewStatus.DEFERRED);
@@ -44,7 +44,7 @@ public class SelectedParticipantContainerHandler implements IMenuPreparer {
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }

--- a/src/main/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandler.java
@@ -52,13 +52,13 @@ public class CancelParticipantSelectionHandler implements IMenuPreparer,IMenuHan
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         boolean selectedStatus = household.getStatus() == InterviewStatus.NOT_DONE;
         return !(selectedStatus);
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }
@@ -96,8 +96,8 @@ public class CancelParticipantSelectionHandler implements IMenuPreparer,IMenuHan
     private void prepareCustomMenus() {
         List<IMenuPreparer> bottomMenus = HouseholdActivityFactory.getCustomMenuPreparer(activity, household);
         for(IMenuPreparer menu:bottomMenus)
-            if(menu.shouldInactivate())
-                menu.inactivate();
+            if(menu.shouldDeactivate())
+                menu.deactivate();
             else
                 menu.activate();
     }

--- a/src/main/java/com/onaio/steps/handler/actions/DeferredHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/DeferredHandler.java
@@ -62,12 +62,12 @@ public class DeferredHandler implements IMenuHandler,IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         return deferredStrategy.shouldInactivate();
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }

--- a/src/main/java/com/onaio/steps/handler/actions/DeleteMemberHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/DeleteMemberHandler.java
@@ -70,7 +70,7 @@ public class DeleteMemberHandler implements IMenuHandler,IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         boolean isSelectedMember = String.valueOf(member.getId()).equals(member.getHousehold().getSelectedMemberId());
         boolean refusedHousehold = member.getHousehold().getStatus().equals(InterviewStatus.REFUSED);
         boolean surveyDone = member.getHousehold().getStatus().equals(InterviewStatus.DONE);
@@ -78,7 +78,7 @@ public class DeleteMemberHandler implements IMenuHandler,IMenuPreparer {
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         MenuItem menuItem = menu.findItem(MENU_ID);
         menuItem.setEnabled(false);
 

--- a/src/main/java/com/onaio/steps/handler/actions/ExportHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/ExportHandler.java
@@ -205,12 +205,12 @@ public class ExportHandler implements IMenuHandler,IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
            return households.isEmpty();
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         MenuItem item = menu.findItem(MENU_ID);
         item.setEnabled(false);
     }

--- a/src/main/java/com/onaio/steps/handler/actions/IncompleteRefusedHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/IncompleteRefusedHandler.java
@@ -75,12 +75,12 @@ public class IncompleteRefusedHandler  implements IMenuHandler,IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         return refusedSurveyStrategy.shouldInactivate();
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }

--- a/src/main/java/com/onaio/steps/handler/actions/RefusedHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/RefusedHandler.java
@@ -72,12 +72,12 @@ public class RefusedHandler implements IMenuHandler,IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         return refusedSurveyStrategy.shouldInactivate();
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }

--- a/src/main/java/com/onaio/steps/handler/actions/SelectParticipantHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/SelectParticipantHandler.java
@@ -71,14 +71,14 @@ public class SelectParticipantHandler implements IMenuHandler, IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         boolean noMember = household.numberOfNonSelectedMembers(db) == 0;
         boolean noSelection = household.getStatus() == InterviewStatus.SELECTION_NOT_DONE;
         return noMember || !noSelection;
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }
@@ -139,8 +139,8 @@ public class SelectParticipantHandler implements IMenuHandler, IMenuPreparer {
     private void prepareCustomMenus() {
         List<IMenuPreparer> bottomMenus = HouseholdActivityFactory.getCustomMenuPreparer(activity, household);
         for(IMenuPreparer menu:bottomMenus)
-            if(menu.shouldInactivate())
-                menu.inactivate();
+            if(menu.shouldDeactivate())
+                menu.deactivate();
             else
                 menu.activate();
     }

--- a/src/main/java/com/onaio/steps/handler/actions/SelectedParticipantActionsHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/SelectedParticipantActionsHandler.java
@@ -35,7 +35,7 @@ public class SelectedParticipantActionsHandler implements IMenuPreparer {
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         boolean selected = household.getStatus() == InterviewStatus.NOT_DONE;
         boolean deferred = household.getStatus() == InterviewStatus.DEFERRED;
         boolean incomplete = household.getStatus() == InterviewStatus.INCOMPLETE;
@@ -43,7 +43,7 @@ public class SelectedParticipantActionsHandler implements IMenuPreparer {
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.GONE);
     }

--- a/src/main/java/com/onaio/steps/handler/actions/SubmitDataHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/SubmitDataHandler.java
@@ -2,7 +2,6 @@ package com.onaio.steps.handler.actions;
 
 import android.app.Dialog;
 import android.app.ListActivity;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -92,12 +91,12 @@ public class SubmitDataHandler implements IMenuHandler,IMenuPreparer, IViewPrepa
     }
 
     @Override
-    public boolean shouldInactivate() {
-        return exportHandler.shouldInactivate();
+    public boolean shouldDeactivate() {
+        return exportHandler.shouldDeactivate();
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         MenuItem item = menu.findItem(MENU_ID);
         item.setEnabled(false);
     }
@@ -121,7 +120,7 @@ public class SubmitDataHandler implements IMenuHandler,IMenuPreparer, IViewPrepa
 
     @Override
     public boolean shouldBeDisabled() {
-        return shouldInactivate();
+        return shouldDeactivate();
     }
 
     @Override

--- a/src/main/java/com/onaio/steps/handler/actions/TakeSurveyHandler.java
+++ b/src/main/java/com/onaio/steps/handler/actions/TakeSurveyHandler.java
@@ -82,12 +82,12 @@ public class TakeSurveyHandler implements IMenuHandler, IMenuPreparer, IActivity
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         return takeSurveyStrategy.shouldInactivate();
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         View item = activity.findViewById(MENU_ID);
         item.setVisibility(View.INVISIBLE);
     }

--- a/src/main/java/com/onaio/steps/handler/activities/EditMemberActivityHandler.java
+++ b/src/main/java/com/onaio/steps/handler/activities/EditMemberActivityHandler.java
@@ -79,7 +79,7 @@ public class EditMemberActivityHandler implements IMenuHandler, IActivityResultH
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         boolean isSelectedMember = String.valueOf(member.getId()).equals(member.getHousehold().getSelectedMemberId());
         boolean refusedHousehold = member.getHousehold().getStatus().equals(InterviewStatus.REFUSED);
         boolean surveyDone = member.getHousehold().getStatus().equals(InterviewStatus.DONE);
@@ -88,7 +88,7 @@ public class EditMemberActivityHandler implements IMenuHandler, IActivityResultH
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         MenuItem menuItem = menu.findItem(MENU_ID);
         menuItem.setEnabled(false);
     }

--- a/src/main/java/com/onaio/steps/handler/activities/EditParticipantActivityHandler.java
+++ b/src/main/java/com/onaio/steps/handler/activities/EditParticipantActivityHandler.java
@@ -75,7 +75,7 @@ public class EditParticipantActivityHandler implements IMenuHandler, IActivityRe
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         boolean doneStatus = participant.getStatus() == InterviewStatus.DONE;
         boolean refusedStatus = participant.getStatus() == InterviewStatus.REFUSED;
         boolean incompleteStatus = participant.getStatus() == InterviewStatus.INCOMPLETE;
@@ -84,7 +84,7 @@ public class EditParticipantActivityHandler implements IMenuHandler, IActivityRe
     }
 
     @Override
-    public void inactivate() {
+    public void deactivate() {
         MenuItem menuItem = menu.findItem(MENU_ID);
         menuItem.setEnabled(false);
     }

--- a/src/main/java/com/onaio/steps/handler/activities/NewMemberActivityHandler.java
+++ b/src/main/java/com/onaio/steps/handler/activities/NewMemberActivityHandler.java
@@ -87,11 +87,11 @@ public class NewMemberActivityHandler implements IMenuHandler, IActivityResultHa
     }
 
     @Override
-    public boolean shouldInactivate() {
+    public boolean shouldDeactivate() {
         return !(household.getStatus().equals(InterviewStatus.SELECTION_NOT_DONE));
     }
 
-    public void inactivate() {
+    public void deactivate() {
         Button button = (Button) activity.findViewById(R.id.action_add_member);
         button.setVisibility(View.GONE);
     }

--- a/src/main/java/com/onaio/steps/handler/factories/HouseholdActivityFactory.java
+++ b/src/main/java/com/onaio/steps/handler/factories/HouseholdActivityFactory.java
@@ -18,6 +18,7 @@ package com.onaio.steps.handler.factories;
 
 import android.app.ListActivity;
 
+import com.onaio.steps.handler.HouseholdActivityBackButtonPreparer;
 import com.onaio.steps.handler.actions.BackHomeHandler;
 import com.onaio.steps.handler.actions.CancelParticipantSelectionHandler;
 import com.onaio.steps.handler.actions.DeferredHandler;
@@ -76,6 +77,7 @@ public class HouseholdActivityFactory {
         menuItems.add(new NewMemberActivityHandler(activity,household));
         menuItems.add(new SelectParticipantHandler(activity,household));
         menuItems.add(new SelectedParticipantContainerHandler(activity,household));
+        menuItems.add(new HouseholdActivityBackButtonPreparer(activity, household));
         menuItems.add(new CancelParticipantSelectionHandler(activity,household));
         return menuItems;
     }

--- a/src/main/java/com/onaio/steps/handler/interfaces/IMenuPreparer.java
+++ b/src/main/java/com/onaio/steps/handler/interfaces/IMenuPreparer.java
@@ -17,7 +17,7 @@
 package com.onaio.steps.handler.interfaces;
 
 public interface IMenuPreparer {
-    boolean shouldInactivate();
-    void inactivate();
+    boolean shouldDeactivate();
+    void deactivate();
     void activate();
 }

--- a/src/main/res/layout/selected_participant.xml
+++ b/src/main/res/layout/selected_participant.xml
@@ -88,6 +88,7 @@
             android:layout_margin="10dp"
             android:background="@android:color/white"
             android:shadowColor="@android:color/black"
+            android:paddingLeft="5dp"
             android:textSize="12sp"/>
         <Button android:id="@+id/action_refused"
             android:layout_width="fill_parent"
@@ -98,6 +99,7 @@
             android:onClick="handleCustomMenu"
             android:layout_margin="10dp"
             android:background="@android:color/white"
+            android:paddingLeft="5dp"
             android:textSize="12sp"/>
         <Button
             android:id="@+id/action_cancel_participant"
@@ -109,8 +111,8 @@
             android:layout_margin="10dp"
             android:background="@android:color/white"
             android:textColor="@android:color/black"
-            android:textSize="12sp"
-            />
+            android:paddingLeft="5dp"
+            android:textSize="12sp" />
 
     </LinearLayout>
     <TextView

--- a/src/test/java/com/onaio/steps/handler/SelectedParticipantContainerHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/SelectedParticipantContainerHandlerTest.java
@@ -53,35 +53,35 @@ public class SelectedParticipantContainerHandlerTest {
     public void ShouldNotInactivateWhenSurveyNotDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        assertFalse(selectedParticipantContainerHandler.shouldInactivate());
+        assertFalse(selectedParticipantContainerHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenMemberIsNotSelected(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        assertTrue(selectedParticipantContainerHandler.shouldInactivate());
+        assertTrue(selectedParticipantContainerHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldActivateWhenHouseholdStatusIsIncomplete(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.INCOMPLETE);
 
-        assertFalse(selectedParticipantContainerHandler.shouldInactivate());
+        assertFalse(selectedParticipantContainerHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldActivateWhenSurveyIsDeferred(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        assertFalse(selectedParticipantContainerHandler.shouldInactivate());
+        assertFalse(selectedParticipantContainerHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldActivateWhenSurveyIsRefused(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        assertTrue(selectedParticipantContainerHandler.shouldInactivate());
+        assertTrue(selectedParticipantContainerHandler.shouldDeactivate());
     }
 
     @Test
@@ -89,7 +89,7 @@ public class SelectedParticipantContainerHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(householdActivity.findViewById(R.id.selected_participant)).toReturn(viewMock);
 
-        selectedParticipantContainerHandler.inactivate();
+        selectedParticipantContainerHandler.deactivate();
 
         verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/CancelParticipantSelectionHandlerTest.java
@@ -69,35 +69,35 @@ public class CancelParticipantSelectionHandlerTest {
     public void ShouldInactivateWhenMemberIsNotSelected(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        assertTrue(selectionHandler.shouldInactivate());
+        assertTrue(selectionHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyNotDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        assertFalse(selectionHandler.shouldInactivate());
+        assertFalse(selectionHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
 
-        assertTrue(selectionHandler.shouldInactivate());
+        assertTrue(selectionHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDeferred(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        assertTrue(selectionHandler.shouldInactivate());
+        assertTrue(selectionHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyRefused(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        assertTrue(selectionHandler.shouldInactivate());
+        assertTrue(selectionHandler.shouldDeactivate());
     }
 
 
@@ -106,7 +106,7 @@ public class CancelParticipantSelectionHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(activityMock.findViewById(MENU_ID)).toReturn(viewMock);
 
-        selectionHandler.inactivate();
+        selectionHandler.deactivate();
 
         verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/DeferredHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/DeferredHandlerTest.java
@@ -82,35 +82,35 @@ public class DeferredHandlerTest {
     public void ShouldInactivateWhenMemberIsNotSelected(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        assertTrue(deferredHandler.shouldInactivate());
+        assertTrue(deferredHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyNotDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        assertFalse(deferredHandler.shouldInactivate());
+        assertFalse(deferredHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
 
-        assertTrue(deferredHandler.shouldInactivate());
+        assertTrue(deferredHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDeferred(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        assertTrue(deferredHandler.shouldInactivate());
+        assertTrue(deferredHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyRefused(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        assertTrue(deferredHandler.shouldInactivate());
+        assertTrue(deferredHandler.shouldDeactivate());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class DeferredHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(activityMock.findViewById(MENU_ID)).toReturn(viewMock);
 
-        deferredHandler.inactivate();
+        deferredHandler.deactivate();
 
         verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/DeleteMemberHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/DeleteMemberHandlerTest.java
@@ -83,7 +83,7 @@ public class DeleteMemberHandlerTest {
         stub(memberMock.getId()).toReturn(1);
         stub(memberMock.getHousehold()).toReturn(new Household("12","name","321","1", InterviewStatus.DEFERRED,"12-12-2001", "uniqueDevId","Dummy comments"));
 
-        assertTrue(deleteMemberHandler.shouldInactivate());
+        assertTrue(deleteMemberHandler.shouldDeactivate());
     }
 
     @Test
@@ -92,14 +92,14 @@ public class DeleteMemberHandlerTest {
         stub(memberMock.getHousehold()).toReturn(new Household("12","name","321","1", InterviewStatus.DEFERRED,"12-12-2001", "uniqueDevId","Dummy comments"));
 
 
-        assertFalse(deleteMemberHandler.shouldInactivate());
+        assertFalse(deleteMemberHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenHouseholdIsSurveyed(){
         stub(memberMock.getId()).toReturn(1);
         stub(memberMock.getHousehold()).toReturn(new Household("12","name","321","", InterviewStatus.DONE,"12-12-2001", "uniqueDevId","Dummy comments"));
-        assertTrue(deleteMemberHandler.shouldInactivate());
+        assertTrue(deleteMemberHandler.shouldDeactivate());
     }
 
     @Test
@@ -107,7 +107,7 @@ public class DeleteMemberHandlerTest {
         stub(memberMock.getId()).toReturn(1);
         stub(memberMock.getHousehold()).toReturn(new Household("12","name","321","", InterviewStatus.REFUSED,"12-12-2001", "uniqueDevId","Dummy comments"));
 
-        assertTrue(deleteMemberHandler.shouldInactivate());
+        assertTrue(deleteMemberHandler.shouldDeactivate());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class DeleteMemberHandlerTest {
         MenuItem menuItemMock = mock(MenuItem.class);
         stub(menuMock.findItem(MENU_ID)).toReturn(menuItemMock);
 
-        deleteMemberHandler.inactivate();
+        deleteMemberHandler.deactivate();
 
         verify(menuItemMock).setEnabled(false);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/ExportHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/ExportHandlerTest.java
@@ -95,7 +95,7 @@ public class ExportHandlerTest {
 //        Mockito.stub( household.numberOfNonDeletedMembers(dbMock)).toReturn(0);
 //
 //        Mockito.stub(dbMock.exec(Mockito.anyString())).toReturn(cursorMock);
-//        assertTrue(exportHandler.shouldInactivate());
+//        assertTrue(exportHandler.shouldDeactivate());
 //    }
 
     @Test
@@ -115,7 +115,7 @@ public class ExportHandlerTest {
         MenuItem menuItemMock = Mockito.mock(MenuItem.class);
         Mockito.stub(menuMock.findItem(R.id.action_export)).toReturn(menuItemMock);
 
-        exportHandler.withMenu(menuMock).inactivate();
+        exportHandler.withMenu(menuMock).deactivate();
 
         Mockito.verify(menuItemMock).setEnabled(false);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/RefusedHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/RefusedHandlerTest.java
@@ -81,35 +81,35 @@ public class RefusedHandlerTest {
     public void ShouldInactivateWhenMemberIsNotSelected(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        assertTrue(refusedHandler.shouldInactivate());
+        assertTrue(refusedHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyNotDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        assertFalse(refusedHandler.shouldInactivate());
+        assertFalse(refusedHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
 
-        assertTrue(refusedHandler.shouldInactivate());
+        assertTrue(refusedHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyDeferred(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        assertFalse(refusedHandler.shouldInactivate());
+        assertFalse(refusedHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyRefused(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        assertTrue(refusedHandler.shouldInactivate());
+        assertTrue(refusedHandler.shouldDeactivate());
     }
 
     @Test
@@ -117,7 +117,7 @@ public class RefusedHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(householdActivityMock.findViewById(MENU_ID)).toReturn(viewMock);
 
-        refusedHandler.inactivate();
+        refusedHandler.deactivate();
 
         verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/SelectParticipantHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/SelectParticipantHandlerTest.java
@@ -108,7 +108,7 @@ public class SelectParticipantHandlerTest {
     public void ShouldInActivateWhenThereAreNoMembers(){
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(0);
 
-        Assert.assertTrue(selectParticipantHandler.shouldInactivate());
+        Assert.assertTrue(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class SelectParticipantHandlerTest {
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.INCOMPLETE);
 
-        Assert.assertTrue(selectParticipantHandler.shouldInactivate());
+        Assert.assertTrue(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -124,7 +124,7 @@ public class SelectParticipantHandlerTest {
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
 
-        Assert.assertTrue(selectParticipantHandler.shouldInactivate());
+        Assert.assertTrue(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -132,7 +132,7 @@ public class SelectParticipantHandlerTest {
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        Assert.assertTrue(selectParticipantHandler.shouldInactivate());
+        Assert.assertTrue(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -140,7 +140,7 @@ public class SelectParticipantHandlerTest {
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        Assert.assertTrue(selectParticipantHandler.shouldInactivate());
+        Assert.assertTrue(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -148,7 +148,7 @@ public class SelectParticipantHandlerTest {
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        Assert.assertTrue(selectParticipantHandler.shouldInactivate());
+        Assert.assertTrue(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -156,7 +156,7 @@ public class SelectParticipantHandlerTest {
         Mockito.stub(householdMock.numberOfNonSelectedMembers(Mockito.any(DatabaseHelper.class))).toReturn(1);
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        Assert.assertFalse(selectParticipantHandler.shouldInactivate());
+        Assert.assertFalse(selectParticipantHandler.shouldDeactivate());
     }
 
     @Test
@@ -166,7 +166,7 @@ public class SelectParticipantHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(householdActivityMock.findViewById(R.id.action_select_participant)).toReturn(viewMock);
 
-        handler.inactivate();
+        handler.deactivate();
 
         Mockito.verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/SelectedParticipantActionsHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/SelectedParticipantActionsHandlerTest.java
@@ -62,42 +62,42 @@ public class SelectedParticipantActionsHandlerTest {
     public void ShouldInactivateWhenMemberIsNotSelected(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        assertTrue(selectedParticipantActionsHandler.shouldInactivate());
+        assertTrue(selectedParticipantActionsHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyNotDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        assertFalse(selectedParticipantActionsHandler.shouldInactivate());
+        assertFalse(selectedParticipantActionsHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
 
-        assertTrue(selectedParticipantActionsHandler.shouldInactivate());
+        assertTrue(selectedParticipantActionsHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldActivateWhenSurveyIncomplete(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.INCOMPLETE);
 
-        assertFalse(selectedParticipantActionsHandler.shouldInactivate());
+        assertFalse(selectedParticipantActionsHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDeferred(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        assertFalse(selectedParticipantActionsHandler.shouldInactivate());
+        assertFalse(selectedParticipantActionsHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyRefused(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        assertTrue(selectedParticipantActionsHandler.shouldInactivate());
+        assertTrue(selectedParticipantActionsHandler.shouldDeactivate());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class SelectedParticipantActionsHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(activityMock.findViewById(MENU_ID)).toReturn(viewMock);
 
-        selectedParticipantActionsHandler.inactivate();
+        selectedParticipantActionsHandler.deactivate();
 
         verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/actions/TakeSurveyHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/actions/TakeSurveyHandlerTest.java
@@ -78,35 +78,35 @@ public class TakeSurveyHandlerTest {
     public void ShouldInactivateWhenMemberIsNotSelected(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
 
-        Assert.assertTrue(takeSurveyHandler.shouldInactivate());
+        Assert.assertTrue(takeSurveyHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyNotDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.NOT_DONE);
 
-        Assert.assertFalse(takeSurveyHandler.shouldInactivate());
+        Assert.assertFalse(takeSurveyHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyDone(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
 
-        Assert.assertTrue(takeSurveyHandler.shouldInactivate());
+        Assert.assertTrue(takeSurveyHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenSurveyDeferred(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.DEFERRED);
 
-        Assert.assertFalse(takeSurveyHandler.shouldInactivate());
+        Assert.assertFalse(takeSurveyHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyRefused(){
         Mockito.stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
 
-        Assert.assertTrue(takeSurveyHandler.shouldInactivate());
+        Assert.assertTrue(takeSurveyHandler.shouldDeactivate());
     }
 
     @Test
@@ -114,7 +114,7 @@ public class TakeSurveyHandlerTest {
         View viewMock = Mockito.mock(View.class);
         Mockito.stub(householdActivityMock.findViewById(R.id.action_take_survey)).toReturn(viewMock);
 
-        takeSurveyHandler.inactivate();
+        takeSurveyHandler.deactivate();
 
         Mockito.verify(viewMock).setVisibility(View.INVISIBLE);
     }

--- a/src/test/java/com/onaio/steps/handler/activities/EditMemberActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/EditMemberActivityHandlerTest.java
@@ -112,7 +112,7 @@ public class EditMemberActivityHandlerTest {
         Mockito.stub(memberMock.getHousehold()).toReturn(household);
         Mockito.stub(memberMock.getId()).toReturn(1);
 
-        assertTrue(editMemberActivityHandler.withMenu(menuMock).shouldInactivate());
+        assertTrue(editMemberActivityHandler.withMenu(menuMock).shouldDeactivate());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class EditMemberActivityHandlerTest {
         Menu menuMock = Mockito.mock(Menu.class);
         stub(memberMock.getId()).toReturn(1);
         stub(memberMock.getHousehold()).toReturn(new Household("12","name","321","", InterviewStatus.DONE,"12-12-2001", "uniqueDevId","Dummy comments"));
-        Assert.assertTrue(editMemberActivityHandler.withMenu(menuMock).shouldInactivate());
+        Assert.assertTrue(editMemberActivityHandler.withMenu(menuMock).shouldDeactivate());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class EditMemberActivityHandlerTest {
         Menu menuMock = Mockito.mock(Menu.class);
         stub(memberMock.getId()).toReturn(1);
         stub(memberMock.getHousehold()).toReturn(new Household("12","name","321","", InterviewStatus.REFUSED,"12-12-2001", "uniqueDevId","Dummy comments"));
-        Assert.assertTrue(editMemberActivityHandler.withMenu(menuMock).shouldInactivate());
+        Assert.assertTrue(editMemberActivityHandler.withMenu(menuMock).shouldDeactivate());
 
     }
 
@@ -149,7 +149,7 @@ public class EditMemberActivityHandlerTest {
         MenuItem menuItemMock = Mockito.mock(MenuItem.class);
         Mockito.stub(menuMock.findItem(R.id.action_edit)).toReturn(menuItemMock);
 
-        editMemberActivityHandler.withMenu(menuMock).inactivate();
+        editMemberActivityHandler.withMenu(menuMock).deactivate();
 
         Mockito.verify(menuItemMock).setEnabled(false);
     }

--- a/src/test/java/com/onaio/steps/handler/activities/EditParticipantActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/EditParticipantActivityHandlerTest.java
@@ -81,28 +81,28 @@ public class EditParticipantActivityHandlerTest {
     public void ShouldInactivateWhenParticipantSurveyIsDone(){
         Menu menuMock = Mockito.mock(Menu.class);
         Mockito.stub(participant.getStatus()).toReturn(InterviewStatus.DONE);
-        Assert.assertTrue(editParticipantActivityHandler.withMenu(menuMock).shouldInactivate());
+        Assert.assertTrue(editParticipantActivityHandler.withMenu(menuMock).shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenParticipantSurveyIsRefused(){
         Menu menuMock = Mockito.mock(Menu.class);
         Mockito.stub(participant.getStatus()).toReturn(InterviewStatus.REFUSED);
-        Assert.assertTrue(editParticipantActivityHandler.withMenu(menuMock).shouldInactivate());
+        Assert.assertTrue(editParticipantActivityHandler.withMenu(menuMock).shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenParticipantSurveyIsIncomplete(){
         Menu menuMock = Mockito.mock(Menu.class);
         Mockito.stub(participant.getStatus()).toReturn(InterviewStatus.INCOMPLETE);
-        Assert.assertTrue(editParticipantActivityHandler.withMenu(menuMock).shouldInactivate());
+        Assert.assertTrue(editParticipantActivityHandler.withMenu(menuMock).shouldDeactivate());
     }
 
     @Test
     public void ShouldNotInactivateWhenParticipantIsSelected(){
         Menu menuMock = Mockito.mock(Menu.class);
         Mockito.stub(participant.getStatus()).toReturn(InterviewStatus.SELECTION_NOT_DONE);
-        Assert.assertFalse(editParticipantActivityHandler.withMenu(menuMock).shouldInactivate());
+        Assert.assertFalse(editParticipantActivityHandler.withMenu(menuMock).shouldDeactivate());
     }
 
     @Test
@@ -122,7 +122,7 @@ public class EditParticipantActivityHandlerTest {
         MenuItem menuItemMock = Mockito.mock(MenuItem.class);
         Mockito.stub(menuMock.findItem(R.id.action_edit)).toReturn(menuItemMock);
 
-        editParticipantActivityHandler.withMenu(menuMock).inactivate();
+        editParticipantActivityHandler.withMenu(menuMock).deactivate();
 
         Mockito.verify(menuItemMock).setEnabled(false);
     }

--- a/src/test/java/com/onaio/steps/handler/activities/NewMemberActivityHandlerTest.java
+++ b/src/test/java/com/onaio/steps/handler/activities/NewMemberActivityHandlerTest.java
@@ -147,21 +147,21 @@ public class NewMemberActivityHandlerTest {
     public void ShouldInactivateWhenHouseholdIsSurveyed(){
         stub(householdMock.getSelectedMemberId()).toReturn("");
         stub(householdMock.getStatus()).toReturn(InterviewStatus.DONE);
-        Assert.assertTrue(newMemberActivityHandler.shouldInactivate());
+        Assert.assertTrue(newMemberActivityHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenHouseholdSurveyIsIncomplete(){
         stub(householdMock.getSelectedMemberId()).toReturn("");
         stub(householdMock.getStatus()).toReturn(InterviewStatus.INCOMPLETE);
-        Assert.assertTrue(newMemberActivityHandler.shouldInactivate());
+        Assert.assertTrue(newMemberActivityHandler.shouldDeactivate());
     }
 
     @Test
     public void ShouldInactivateWhenSurveyIsRefused(){
         stub(householdMock.getSelectedMemberId()).toReturn("");
         stub(householdMock.getStatus()).toReturn(InterviewStatus.REFUSED);
-        Assert.assertTrue(newMemberActivityHandler.shouldInactivate());
+        Assert.assertTrue(newMemberActivityHandler.shouldDeactivate());
     }
 
     @Test
@@ -169,7 +169,7 @@ public class NewMemberActivityHandlerTest {
         View viewMock = Mockito.mock(Button.class);
         stub(householdActivityMock.findViewById(R.id.action_add_member)).toReturn(viewMock);
 
-        newMemberActivityHandler.inactivate();
+        newMemberActivityHandler.deactivate();
 
         verify(viewMock).setVisibility(View.GONE);
     }

--- a/src/test/java/com/onaio/steps/handler/factories/HouseholdActivityFactoryTest.java
+++ b/src/test/java/com/onaio/steps/handler/factories/HouseholdActivityFactoryTest.java
@@ -19,6 +19,7 @@ package com.onaio.steps.handler.factories;
 import android.content.Intent;
 
 import com.onaio.steps.activities.HouseholdActivity;
+import com.onaio.steps.handler.HouseholdActivityBackButtonPreparer;
 import com.onaio.steps.handler.actions.BackHomeHandler;
 import com.onaio.steps.handler.actions.CancelParticipantSelectionHandler;
 import com.onaio.steps.handler.actions.DeferredHandler;
@@ -103,7 +104,7 @@ public class HouseholdActivityFactoryTest extends TestCase {
 
         ArrayList<Class> menuHandlerTypes = getTypes(menuHandlers);
 
-        assertEquals(9, menuHandlers.size());
+        assertEquals(10, menuHandlers.size());
         Assert.assertTrue(menuHandlerTypes.contains(TakeSurveyHandler.class));
         Assert.assertTrue(menuHandlerTypes.contains(DeferredHandler.class));
         Assert.assertTrue(menuHandlerTypes.contains(RefusedHandler.class));
@@ -113,6 +114,7 @@ public class HouseholdActivityFactoryTest extends TestCase {
         Assert.assertTrue(menuHandlerTypes.contains(SelectedParticipantContainerHandler.class));
         Assert.assertTrue(menuHandlerTypes.contains(CancelParticipantSelectionHandler.class));
         Assert.assertTrue(menuHandlerTypes.contains(IncompleteRefusedHandler.class));
+        Assert.assertTrue(menuHandlerTypes.contains(HouseholdActivityBackButtonPreparer.class));
 
     }
 


### PR DESCRIPTION
Disable the back button in the HouseholdActivity only when the interview
status for the household is NOT_DONE

Fix for issue #74

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>