### PR TITLE
Signing Release APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,42 @@ STEPS is an Android application developed for the World Health Organization's ST
 ![screenshot 1](screenshots/screen1.png) ![screenshot 2](screenshots/screen2.png) ![screenshot 3](screenshots/screen3.png)
 
 For more information, see http://www.who.int/chp/steps/en/.
+
+## Building the app
+
+Make sure the Gradle daemon (version 2.2.1) is installed on your build machine. Build the app by running:
+
+```
+gradle assembleDebug
+```
+
+It's good practice to sign the app before you release the app. If you don't already have a certificate for signing the APK, you can create one by running:
+
+```
+cd ~/.android
+keytool -genkey -v -keystore release.keystore -alias androidreleasekey -keyalg RSA -keysize 2048 -validity 10000
+```
+
+You can show the key's SHA1 fingerprint by running:
+
+```
+keytool -v -list -keystore release.keystore
+```
+
+Add the following lines to the local.properties file in the project's root directory (you might have to create it):
+
+```
+store_file=/home/[username]/.android/release.keystore
+store_password=your_key_store_pw
+key_alias=androidreleasekey
+key_password=your_release_key_pw
+```
+
+You can now generate a signed release APK by running:
+
+```
+gradle clean
+gradle assembleRelease
+```
+
+The signed APK (`build/outputs/apk/steps-app-release.apk`) should be available for distribution if the build was successful.

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,33 @@ android {
         versionName "2.8"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
+    signingConfigs {
+        release {
+            if (project.rootProject.file("local.properties").exists()) {
+                Properties properties = new Properties()
+                properties.load(project.rootProject.file("local.properties").newDataInputStream())
+                if (properties != null &&
+                        properties.containsKey("store_file") &&
+                        properties.containsKey("store_password") &&
+                        properties.containsKey("key_alias") &&
+                        properties.containsKey("key_password")) {
+                    storeFile file(new File(properties["store_file"]));
+                    storePassword properties["store_password"];
+                    keyAlias properties["key_alias"];
+                    keyPassword properties["key_password"];
+                } else {
+                    println("One of the following properties not set: store_file, store_password, key_alias or key_password");
+                }
+            } else {
+                println("local.properties does not exist");
+            }
+        }
+    }
+    buildTypes {
+        release {
+            signingConfig signingConfigs.release
+        }
+    }
     android {
         packagingOptions {
             exclude 'META-INF/LICENSE.txt'


### PR DESCRIPTION
Add support for signing the release APK in the build.gradle file

Part of fix for issue #41

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>